### PR TITLE
Change copyright to BSD-3-Clause

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,3 +1,8 @@
-All the stuff contained is this repository is entirely free and may be used,
-copied, modified, distributed and what-so-ever without any constraint.
+Copyright (c) 2021 Cedric Dufour. All rights reserved.
 
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Hi @cedric-dufour !

First of all, thanks for sharing your code.

Unfortunately, no code can be used for people which want to comply with standard open-source licenses.
The current copyright is not OSI-approved nor Free/FSF License (check https://spdx.org/licenses/ )

Please consider switching to a well-known and simple free license reflecting the original copyright text.

This pull-request suggest to change to a [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause) with no author change.
