### PR TITLE
urllib3.response.HTTPResponse.from_httplib does not exists anymore and is not needed any longer!

### DIFF
--- a/misc/m2requests.py
+++ b/misc/m2requests.py
@@ -154,7 +154,8 @@ class M2HttpsAdapter(requests.adapters.BaseAdapter):
 
         # Get response
         # REF: https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse
-        resp = urllib3.response.HTTPResponse.from_httplib(conn.getresponse())
+        # REF: https://docs.python.org/3/library/http.client.html#http.client.HTTPConnection.getresponse
+        resp = conn.getresponse()
 
         # Build output response
         # REF: https://github.com/psf/requests/blob/master/requests/adapters.py


### PR DESCRIPTION
Hi @cedric-dufour !

Calling urllib3.response.HTTPResponse.from_httplib in your excellent misc/m2requests.py is no longer possible, because in newer versions this function does not exists any more!
The good news is that it is no longer needed!

This pull-request suggest to remove the call so your script is working with newer versions of the urllib3.

P.S.: Consider replacing https://github.com/psf/requests/blob/master/requests/adapters.py by https://github.com/psf/requests/blob/main/src/requests/adapters.py, too. ("/master/" is replaced by "/main/" here on github some time ago)